### PR TITLE
feat: text buttons styles and update the height to buttons and inputs

### DIFF
--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -317,7 +317,9 @@ export default css`
   .button--text {
     background-color: transparent;
     border-color: transparent;
-    color: var(--o-color-primary-600);
+    color: var(--o-color-neutral-1000);
+    text-decoration: underline;
+    text-underline-offset: 5px;
   }
 
   .button--text:hover:not(.button--disabled) {

--- a/src/themes/light.css
+++ b/src/themes/light.css
@@ -322,9 +322,9 @@
   --o-button-font-size-large: var(--o-font-size-large);
 
   /* Inputs */
-  --o-input-height-small: 2.5rem; /* 40px */
-  --o-input-height-medium: 3rem; /* 48px */
-  --o-input-height-large: 3.5rem; /* 56px */
+  --o-input-height-small: 3rem; /* 48px */
+  --o-input-height-medium: 3.5rem; /* 56px */
+  --o-input-height-large: 4rem; /* 64px */
 
   --o-input-background-color: var(--o-color-neutral-0);
   --o-input-background-color-hover: var(--o-color-neutral-0);


### PR DESCRIPTION
- set black color on text button
- add underline with 5px offset
- set 48px as small, 56px medium and 64px large for height of buttons and inputs